### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![devDependency Status](https://david-dm.org/artemave/37-pieces-of-flair/dev-status.png)](https://david-dm.org/artemave/37-pieces-of-flair#info=devDependencies)
 [![Still Maintained](http://stillmaintained.com/artemave/37-pieces-of-flair.png)](http://stillmaintained.com/artemave/37-pieces-of-flair)
 [![Code Climate](https://codeclimate.com/github/artemave/37-pieces-of-flair.png)](https://codeclimate.com/github/artemave/37-pieces-of-flair)
+[![Inline docs](http://inch-pages.github.io/github/artemave/37-pieces-of-flair.png)](http://inch-pages.github.io/github/artemave/37-pieces-of-flair)
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/artemave/37-pieces-of-flair/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 [![wercker status](https://app.wercker.com/status/dbb3610426d65fd5699570ca58f942ce/s/master "wercker status")](https://app.wercker.com/project/bykey/dbb3610426d65fd5699570ca58f942ce)
 [![gittip](http://img.shields.io/gittip/artemave.svg)](http://img.shields.io/gittip/artemave.svg)


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/artemave/37-pieces-of-flair.png)

Your status page for this project is http://inch-pages.github.io/github/artemave/37-pieces-of-flair

This seems like an interesting collection of badges. I especially dig the Netscape one! :+1: 
