### PR TITLE
Update docs badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![devDependency Status](https://david-dm.org/artemave/37-pieces-of-flair/dev-status.png)](https://david-dm.org/artemave/37-pieces-of-flair#info=devDependencies)
 [![Still Maintained](http://stillmaintained.com/artemave/37-pieces-of-flair.png)](http://stillmaintained.com/artemave/37-pieces-of-flair)
 [![Code Climate](https://codeclimate.com/github/artemave/37-pieces-of-flair.png)](https://codeclimate.com/github/artemave/37-pieces-of-flair)
-[![Inline docs](http://inch-pages.github.io/github/artemave/37-pieces-of-flair.png)](http://inch-pages.github.io/github/artemave/37-pieces-of-flair)
+[![Inline docs](http://inch-ci.org/github/artemave/37-pieces-of-flair.png)](http://inch-ci.org/github/artemave/37-pieces-of-flair)
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/artemave/37-pieces-of-flair/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 [![wercker status](https://app.wercker.com/status/dbb3610426d65fd5699570ca58f942ce/s/master "wercker status")](https://app.wercker.com/project/bykey/dbb3610426d65fd5699570ca58f942ce)
 [![gittip](http://img.shields.io/gittip/artemave.svg)](http://img.shields.io/gittip/artemave.svg)


### PR DESCRIPTION
Update the URL of the docs badge to include it from inch-ci.org instead of inch-pages.github.io (the former being the successor of the Inch Pages project).

[ci skip]
